### PR TITLE
Add super simple deployment strategy for deploying from develop to the development server

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,12 +37,10 @@ script:
 #  when a new tag is created in master. You"ll also need to generate a dedicated API key for this project in pypi
 #  and encrypt the key with "travis encrypt PYPI_TOKEN=<value> --add env.global --com"
 # --------------------------------------------------------------------------
-# deploy:
-#   provider: script
-#   script: poetry config pypi-token.pypi $PYPI_TOKEN && poetry publish --build
-#   skip_cleanup: true
-#   on:
-#     tags: true
-#     branch: master
-#     condition: $NAUTOBOT_VER = master
-#     python: 3.7
+deploy:
+  provider: script
+  script: ./continuous_deployment.sh
+  skip_cleanup: true
+  on:
+    branch: develop
+    python: 3.7

--- a/continuous_deployment.sh
+++ b/continuous_deployment.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Hardcoded IP for the development server
+TARGET_HOST_IP=159.65.241.133
+
+if [ -z "$TARGET_HOST_KEY" ]
+then
+    echo "TARGET_HOST_KEY has not been provided."
+    exit 1
+else
+    mkdir -p ~/.ssh
+    echo "${TARGET_HOST_KEY}" >> ~/.ssh/ssh_key_ipfabric
+    chmod 600 ~/.ssh/ssh_key_ipfabric
+fi
+
+echo "INFO: Connecting via SSH to ${TARGET_HOST_IP}"
+
+# There are a lot of assumptions taken to simplify such as:
+# - the folder /opt/chatbot-ipfabric is there and git is already cloned and has a deployment key to interact with git
+# - poetry is installed
+
+ssh -t -o StrictHostKeyChecking=no root@"${TARGET_HOST_IP}" -i  ~/.ssh/ssh_key_ipfabric << EOF
+    cd /opt/chatbot-ipfabric
+    git checkout develop
+    git reset --hard origin/develop
+    poetry install
+    poetry run inv build && poetry run inv stop && poetry run inv start
+EOF
+
+echo "INFO: Server has been pulled latest develop branch and restarted the development environment"


### PR DESCRIPTION
In short, trying to emulate what we were doing manually in the server to:
1. Push latest changes from develop
2. Build and restart the server in development mode

It is doing several assumptions (that we can do as this server is not changing) such as:
* The GIT deployment key is in the server
* The repo is initialized in /opt/chatbot-ipfabric
* Poetry is installed

The only secret we are passing from travis to the script is the SSH key to reach the server as `TARGET_HOST_KEY`