### PR TITLE
Remove loaded snapshot table from set_snapshot prompt

### DIFF
--- a/nautobot_chatops_ipfabric/worker.py
+++ b/nautobot_chatops_ipfabric/worker.py
@@ -61,7 +61,6 @@ def ipfabric(subcommand, **kwargs):
 def prompt_snapshot_id(action_id, help_text, dispatcher, choices=None):
     """Prompt the user for snapshot ID."""
     formatted_snapshots = ipfabric_api.get_formatted_snapshots()
-    get_snapshots_table(dispatcher, formatted_snapshots)
     choices = list(formatted_snapshots.values())
     default = choices[0]
     dispatcher.prompt_from_menu(action_id, help_text, choices, default=default)


### PR DESCRIPTION
This PR removes the display of the loaded snapshot table during the setting of a snapshot command.

The `get-loaded-snapshot` is a separate command with different header and ends up complicating the `set-snapshot` operation output.